### PR TITLE
Add Babel as a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "es6"
   ],
   "devDependencies": {
+    "babel": "latest",
     "babelify": "latest",
     "browser-sync": "latest",
     "browserify": "latest",


### PR DESCRIPTION
This fixes the problem of not having installed `babel` as a global dependency, which makes running `npm install` fail trying to execute `babel -d lib/ src/`.
