### PR TITLE
Add more browsers compatibility 

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,7 +10,7 @@ var browserSync = require('browser-sync');
 var reload = browserSync.reload;
 
 var config = {
-  entryFile: './examples/oauth.js',
+  entryFile: './examples/basic.js',
   outputDir: './dist/',
   outputFile: 'app.js'
 };

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,7 +23,7 @@ gulp.task('clean', function(cb){
 var bundler;
 function getBundler() {
   if (!bundler) {
-    bundler = watchify(browserify(config.entryFile, _.extend({ debug: true }, watchify.args)));
+    bundler = watchify(browserify([require.resolve("whatwg-fetch/fetch"), require.resolve("core-js/fn/symbol"),require.resolve("core-js/fn/promise"), config.entryFile], _.extend({ debug: true }, watchify.args)));
   }
   return bundler;
 };

--- a/package.json
+++ b/package.json
@@ -26,5 +26,9 @@
   },
   "author": "loverajoel",
   "license": "MIT",
-  "main": "lib/index.js"
+  "main": "lib/index.js",
+  "dependencies": {
+    "core-js": "^1.2.0",
+    "whatwg-fetch": "^0.9.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,34 +1,34 @@
 {
   "name": "spotify-sdk",
-  "version": "0.0.23",
+  "version": "0.0.28",
   "repository": "loverajoel/spotify-sdk",
   "keywords": [
     "spotify-sdk",
     "spotify",
     "es6"
   ],
+  "dependencies": {
+    "core-js": "^1.2.0",
+    "whatwg-fetch": "^0.9.0"
+  },
   "devDependencies": {
-    "babel": "latest",
-    "babelify": "latest",
-    "browser-sync": "latest",
-    "browserify": "latest",
+    "babel": "5.8.23",
+    "babelify": "6.3.0",
+    "browser-sync": "2.9.7",
+    "browserify": "11.2.0",
     "gulp": "latest",
     "gulp-rename": "latest",
-    "rimraf": "latest",
-    "watchify": "latest",
-    "vinyl-source-stream": "latest",
-    "lodash": "latest"
+    "rimraf": "2.4.3",
+    "watchify": "3.4.0",
+    "vinyl-source-stream": "1.1.0",
+    "lodash": "3.10.1"
   },
   "scripts": {
     "watch": "gulp watch",
-    "build": "babel -d lib/ src/",
+    "build": "NODE_ENV=production babel -d lib/ src/",
     "prepublish": "npm run build"
   },
   "author": "loverajoel",
   "license": "MIT",
-  "main": "lib/index.js",
-  "dependencies": {
-    "core-js": "^1.2.0",
-    "whatwg-fetch": "^0.9.0"
-  }
+  "main": "lib/index.js"
 }


### PR DESCRIPTION
#### What does this PR do?

Add `core-js` and `github/fetch` polyfill in order to add more browsers compatibility.
Only use `Promise`, `Symbol` and `fetch`.
#### Question?

It's responsibility of the SDK add old browsers compatibility or of the implementation?
#### What are the relevant tickets?

https://github.com/loverajoel/spotify-sdk/issues/7
