### PR TITLE
Encode search query parameters to handle better non-ascii text - Fixes #13

### DIFF
--- a/src/handlers/AlbumHandler.js
+++ b/src/handlers/AlbumHandler.js
@@ -21,7 +21,7 @@ class AlbumHandler {
      * @return {Collection} albumsCollection
      */
     search(name, query) {
-        return Client.instance.request(`/search?type=album&q=${name}`, 'GET', query);
+        return Client.instance.request(`/search?type=album&q=${encodeURIComponent(name)}`, 'GET', query);
     }
 
     /*

--- a/src/handlers/ArtistHandler.js
+++ b/src/handlers/ArtistHandler.js
@@ -21,7 +21,7 @@ class ArtistHandler {
      * @return {Collection} artistCollection
      */
     search(name, query) {
-        return Client.instance.request(`/search?type=artist&q=${name}`, 'GET', query);
+        return Client.instance.request(`/search?type=artist&q=${encodeURIComponent(name)}`, 'GET', query);
     }
 
     /*

--- a/src/handlers/PlaylistHandler.js
+++ b/src/handlers/PlaylistHandler.js
@@ -21,7 +21,7 @@ class PlaylistHandler {
      * @return {Collection} playlistCollection
      */
     search(name, query) {
-        return Client.instance.request(`/search?type=playlist&q=${name}`, 'GET', query);
+        return Client.instance.request(`/search?type=playlist&q=${encodeURIComponent(name)}`, 'GET', query);
     }
 
     /*

--- a/src/handlers/TrackHandler.js
+++ b/src/handlers/TrackHandler.js
@@ -21,7 +21,7 @@ class TrackHandler {
      * @return {Collection} trackCollection
      */
     search(name, query) {
-        return Client.instance.request(`/search?type=track&q=${name}`, 'GET', query);
+        return Client.instance.request(`/search?type=track&q=${encodeURIComponent(name)}`, 'GET', query);
     }
 
     /*


### PR DESCRIPTION
This should fix the issue with the `q` query parameter when searching Spotify entities.

I couldn't test these changes because the project wouldn't build for me. I'm seeing:

```
[07:38:46] Starting 'build-persistent'...
Error: Parsing file /Users/jmperez/spotify-sdk/examples/oauth.js: 'import' and 'export' may appear only with 'sourceType: module' (8:0)
```
