### PR TITLE
Set Client.fetch() method default 'GET'. Spelling fixes.

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -31,7 +31,7 @@ class Client {
    * @return {Object} instance
    */
   static get instance() {
-    if(!this[singleton]) {
+    if (!this[singleton]) {
       this[singleton] = new Client(singletonEnforcer);
     }
     return this[singleton];
@@ -75,11 +75,11 @@ class Client {
    * @return {Function|Promise}
    */
   login(callback) {
-    let url_login = 'https://accounts.spotify.com/en/authorize?response_type=token&client_id='+
-            this._clientId+'&redirect_uri='+encodeURIComponent(this._redirect_uri)+
-            ( this._scopes ? '&scope=' + encodeURIComponent( this._scopes) : '');
+    let url_login = 'https://accounts.spotify.com/en/authorize?response_type=token&client_id=' +
+      this._clientId + '&redirect_uri=' + encodeURIComponent(this._redirect_uri) +
+      ( this._scopes ? '&scope=' + encodeURIComponent(this._scopes) : '');
     if (callback) {
-        return callback(url_login);
+      return callback(url_login);
     } else {
       return new Promise((resolve) => {
         resolve(url_login);
@@ -90,11 +90,11 @@ class Client {
   /**
    * @param  {String} url Endpoint
    * @param  {String} method Method GET, POST, PUT or DELETE
-   * @param  {Object} body Objet to send in the body
+   * @param  {Object} body Object to send in the body
    * @return {Promise}
    */
   request(url, method, body) {
-    return this.fetch(url, method, body).then(function(data) {
+    return this.fetch(url, method, body).then(function (data) {
       return Factory(data);
     }.bind(this));
   }
@@ -107,7 +107,7 @@ class Client {
    */
   toQueryString(obj) {
     let str = [];
-    for(let p in obj)
+    for (let p in obj)
       if (obj.hasOwnProperty(p)) {
         str.push(encodeURIComponent(p) + "=" + encodeURIComponent(obj[p]));
       }
@@ -116,14 +116,16 @@ class Client {
 
   /**
    * @param  {String} endpoint Endpoint
-   * @param  {String} method Method GET, POST, PUT or DELETE
-   * @param  {Object} body Objet to send in the body
+   * @param  {String} method Method GET, POST, PUT or DELETE (default GET)
+   * @param  {Object} body Object to send in the body
    * @return {Promise}
    */
   fetch(endpoint, method, body) {
-    let _headers = { 'Accept': 'application/json'};
+    let _headers = {'Accept': 'application/json'};
     let _url;
     let _body;
+
+    method = method || 'GET';
 
     if (this._token) {
       _headers.Authorization = `Bearer ${this._token}`;
@@ -138,7 +140,7 @@ class Client {
     if (method === 'GET') {
       if (body) {
         let separator = _url.indexOf('?') !== -1 ? "&" : "?";
-        _url = _url+separator+this.toQueryString(body);
+        _url = _url + separator + this.toQueryString(body);
       }
     } else {
       _body = JSON.stringify(body);
@@ -152,21 +154,21 @@ class Client {
         error.response = response;
         throw error;
       }
-    }
+    };
 
     let parseJSON = (response) => {
       if (response.statusText === 'No Content') {
-        return { type: 'undefineds' };
+        return {type: 'undefineds'};
       }
       return response.json();
-    }
+    };
 
     return fetch(_url, {
-      method: method || 'GET',
+      method : method,
       headers: _headers,
-      body: _body
+      body   : _body
     }).then(checkStatus)
-    .then(parseJSON)
+      .then(parseJSON)
   };
 }
 


### PR DESCRIPTION
A bug I noticed while creating the unit test for Client.fetch() ...
If 'method' is not set, the structure is POST (no query string, body set) but 'method' on the request is GET.

  `if (method === 'GET') {` ...
     assumes post while 
  `method: method || 'GET',` ...
     assumes get

I moved to the top:
  `method = method || 'GET';`

Also a few trivial spelling corrections. I believe the whitespace changes are consistent with your styling preferences.
