### PR TITLE
docs: Fix simple typo, retrive -> retrieve

### DIFF
--- a/src/handlers/AlbumHandler.js
+++ b/src/handlers/AlbumHandler.js
@@ -30,7 +30,7 @@ class AlbumHandler {
    * @see https://developer.spotify.com/web-api/get-album/
    *
    * @public
-   * @param {String|Array} ids Album id/ids to retrive
+   * @param {String|Array} ids Album id/ids to retrieve
    * @param {Object} [query] Query parameters.
    * @returns {Promise} Album|albumsCollection
    */

--- a/src/handlers/ArtistHandler.js
+++ b/src/handlers/ArtistHandler.js
@@ -30,7 +30,7 @@ class ArtistHandler {
    * @see https://developer.spotify.com/web-api/get-artist/
    *
    * @public
-   * @param {String|Array} ids Artist id/ids to retrive
+   * @param {String|Array} ids Artist id/ids to retrieve
    * @param {Object} [query] Query parameters.
    * @return {Promise} Artist|artistCollection
    */
@@ -48,7 +48,7 @@ class ArtistHandler {
    * @see https://developer.spotify.com/web-api/get-artists-albums/
    *
    * @public
-   * @param {String} id Artist id to retrive
+   * @param {String} id Artist id to retrieve
    * @param {Object} [query] Query parameters.
    * @return {Promise} albumsCollection
    */
@@ -62,7 +62,7 @@ class ArtistHandler {
    * @see https://developer.spotify.com/web-api/get-artists-top-tracks/
    *
    * @public
-   * @param {String} id Artist id to retrive top tracks
+   * @param {String} id Artist id to retrieve top tracks
    * @param {Object} [query] Query parameters.
    * @return {Promise} tracksCollection
    */
@@ -76,7 +76,7 @@ class ArtistHandler {
    * @see https://developer.spotify.com/web-api/get-related-artists/
    *
    * @public
-   * @param {String} id Artist id to retrive related artists
+   * @param {String} id Artist id to retrieve related artists
    * @param {Object} [query] Query parameters.
    * @return {Promise} albumsCollection
    */

--- a/src/handlers/TrackHandler.js
+++ b/src/handlers/TrackHandler.js
@@ -30,7 +30,7 @@ class TrackHandler {
      * @see https://developer.spotify.com/web-api/get-albums-tracks/ FIXME: check the url
      *
      * @public
-     * @param {String|Array} ids Track id/ids to retrive
+     * @param {String|Array} ids Track id/ids to retrieve
      * @param {Object} [query] Query parameters.
      * @return {Promise} Track|trackCollection
      */

--- a/src/handlers/UserHandler.js
+++ b/src/handlers/UserHandler.js
@@ -29,7 +29,7 @@ class UserHandler {
    * @see https://developer.spotify.com/web-api/get-users-profile/
    *
    * @public
-   * @param {String} id User id to retrive
+   * @param {String} id User id to retrieve
    * @required {OAuth}
    * @return {Promise} User
    */
@@ -44,7 +44,7 @@ class UserHandler {
    *
    * @public
    * @param {String} id User User id
-   * @param {String} [playlistId] id to retrive playlists
+   * @param {String} [playlistId] id to retrieve playlists
    * @param {Object} [query] Query parameters.
    * @required {OAuth}
    * @return {Promise} playlistCollection


### PR DESCRIPTION
There is a small typo in src/handlers/AlbumHandler.js, src/handlers/ArtistHandler.js, src/handlers/TrackHandler.js, src/handlers/UserHandler.js.

Should read `retrieve` rather than `retrive`.

